### PR TITLE
Split LoadImage in run into separate method from transform

### DIFF
--- a/run.go
+++ b/run.go
@@ -1,5 +1,7 @@
 package sqip
-
+import (
+	"image"
+)
 // Run takes a file and primitve related config properties and creates a SVG-based LQIP image.
 func Run(file string, workSize, count, mode, alpha, repeat, workers int, background string) (out string, width, height int, err error) {
 	// Load image
@@ -7,6 +9,12 @@ func Run(file string, workSize, count, mode, alpha, repeat, workers int, backgro
 	if err != nil {
 		return "", 0, 0, err
 	}
+
+	return RunLoaded(image, workSize, count, mode, alpha, repeat, workers, background)
+}
+
+//RunLoaded takes an already loaded image and config properties to generate an SVG LQIP
+func RunLoaded(image image.Image, workSize, count, mode, alpha, repeat, workers int, background string) (out string, width, height int, err error) {
 	// Use image-size to retrieve the width and height dimensions of the input image
 	// We need these sizes to pass to Primitive and to write the SVG viewbox
 	w, h := ImageWidthAndHeight(image)


### PR DESCRIPTION
Moving the LoadImage call into its own method (or more accurately moving everything else out) allows the new RunLoaded call to be performed on an image held in memory, having already been opened or generated etc.

This change maintains past functionality and adds a way to save some disk time