### PR TITLE
Add refit function to run

### DIFF
--- a/run.go
+++ b/run.go
@@ -27,6 +27,10 @@ func RunLoaded(image image.Image, workSize, count, mode, alpha, repeat, workers 
 		return "", 0, 0, err
 	}
 
+	// resize BG to match original
+	// Ensures agreement between viewBox and actual content
+	svg = Refit(svg, w, h)
+
 	// minify svg
 	svg, err = Minify(svg)
 	if err != nil {

--- a/svg.go
+++ b/svg.go
@@ -16,7 +16,7 @@ var captureGroup = regexp.MustCompile(`^(.*?)(<g)(.*?)$`)
 var captureSVGOpen = regexp.MustCompile(`(<svg)(.*?)(>)`)
 
 //Capture the (pre-minified) background rectangle
-var captureBackground = regexp.MustCompile(`<rect.*fill="(.*)".*/>`)
+var captureBackground = regexp.MustCompile(`<rect.*?fill="([#a-f0-9]*)".*?/>`)
 
 // Blur adds viewbox and preserveAspectRatio attributes as well as
 // a Gaussian Blur filter to the SVG.

--- a/svg.go
+++ b/svg.go
@@ -15,6 +15,9 @@ var matchSVGClose = regexp.MustCompile(`</svg>`)
 var captureGroup = regexp.MustCompile(`^(.*?)(<g)(.*?)$`)
 var captureSVGOpen = regexp.MustCompile(`(<svg)(.*?)(>)`)
 
+//Capture the (pre-minified) background rectangle
+var captureBackground = regexp.MustCompile(`<rect.*fill="(.*)".*/>`)
+
 // Blur adds viewbox and preserveAspectRatio attributes as well as
 // a Gaussian Blur filter to the SVG.
 // When no group is found, add group (element with blur applied) using patchSVGGroup().
@@ -60,4 +63,11 @@ func patchSVGGroup(svg string) (string, error) {
 
 	res := fmt.Sprintf("%s%s%s</g></svg>", svg[0:startIndex], group, svg[startIndex:endIndex])
 	return res, nil
+}
+
+// Refit adjusts the width of the background to exactly match the output size
+// This will prevent rounding errors causing the aspect ratio to become incorrect
+// This must be called before minify
+func Refit(in string, width int, height int) (out string) {
+	return captureBackground.ReplaceAllString(in, fmt.Sprintf("<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"${1}\" />", width, height))
 }

--- a/svg_test.go
+++ b/svg_test.go
@@ -13,6 +13,9 @@ const (
 	specialSVGPatched = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 750 937'><path fill='#5e5145' d='M0 0h750v937H0z'/><g filter='url(#c)' fill-opacity='.5'><path fill='#ffceae' fill-opacity='.5' d='M455.7 108l7.3 600.2L31.1 561.8z'/><ellipse fill-opacity='.5' rx='1' ry='1' transform='matrix(95.1777 101.02218 -375.52495 353.79954 302.3 76.1)'/><path fill='#fff1cf' fill-opacity='.5' d='M441 979l113.5-292.7L357 752.2z'/><ellipse fill='#00110b' fill-opacity='.5' rx='1' ry='1' transform='matrix(-118.08246 -24.86798 90.92995 -431.76942 634.4 845.2)'/><ellipse fill-opacity='.5' rx='1' ry='1' transform='matrix(-56.65586 45.16032 -103.38974 -129.70753 285.9 891.6)'/><path fill='#370000' fill-opacity='.5' d='M287.3 518h73.2v245h-73.2z'/><path fill='#fffff2' fill-opacity='.5' d='M130 543.5l164.6 172L258 499.7z'/><path fill='#baf8ff' fill-opacity='.5' d='M629 289.5l-2.5-73.2 124.3-4.3 2.6 73.1z'/><ellipse fill='#000002' fill-opacity='.5' rx='1' ry='1' transform='matrix(-125.36617 -5.50313 3.40138 -77.48636 645.6 36)'/><path fill='#001109' fill-opacity='.5' d='M382.6 434.2l33.7-60.8 134.5 74.5-33.8 60.8z'/></g></svg>`
 	// final result of problematic image
 	specialSVGFinal = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 937"><filter id="c"><feGaussianBlur stdDeviation="55" /></filter><path fill='#5e5145' d='M0 0h750v937H0z'/><g filter='url(#c)' fill-opacity='.5'><path fill='#ffceae' fill-opacity='.5' d='M455.7 108l7.3 600.2L31.1 561.8z'/><ellipse fill-opacity='.5' rx='1' ry='1' transform='matrix(95.1777 101.02218 -375.52495 353.79954 302.3 76.1)'/><path fill='#fff1cf' fill-opacity='.5' d='M441 979l113.5-292.7L357 752.2z'/><ellipse fill='#00110b' fill-opacity='.5' rx='1' ry='1' transform='matrix(-118.08246 -24.86798 90.92995 -431.76942 634.4 845.2)'/><ellipse fill-opacity='.5' rx='1' ry='1' transform='matrix(-56.65586 45.16032 -103.38974 -129.70753 285.9 891.6)'/><path fill='#370000' fill-opacity='.5' d='M287.3 518h73.2v245h-73.2z'/><path fill='#fffff2' fill-opacity='.5' d='M130 543.5l164.6 172L258 499.7z'/><path fill='#baf8ff' fill-opacity='.5' d='M629 289.5l-2.5-73.2 124.3-4.3 2.6 73.1z'/><ellipse fill='#000002' fill-opacity='.5' rx='1' ry='1' transform='matrix(-125.36617 -5.50313 3.40138 -77.48636 645.6 36)'/><path fill='#001109' fill-opacity='.5' d='M382.6 434.2l33.7-60.8 134.5 74.5-33.8 60.8z'/></g></svg>`
+	// Test refit changes rect width
+	preRefitSVG = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="189" height="280"><rect x="0" y="0" width="189" height="280" fill="#242221" /><g transform="scale(1.093750) translate(0.5 0.5)"><polygon fill="#ffffff" fill-opacity="0.501961" points="34,49 35,99 151,59" /></g></svg>`
+	postRefitSVG = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="189" height="280"><rect x="0" y="0" width="190" height="280" fill="#242221" /><g transform="scale(1.093750) translate(0.5 0.5)"><polygon fill="#ffffff" fill-opacity="0.501961" points="34,49 35,99 151,59" /></g></svg>`
 )
 
 func Test_regexp(t *testing.T) {
@@ -71,5 +74,13 @@ func TestBlur_special(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("Blur()\ngot = %v\nwant = %v", got, want)
+	}
+}
+
+func TestRefit(t *testing.T) {
+	want := postRefitSVG
+	got := Refit(preRefitSVG, 190, 280)
+	if got != want {
+		t.Errorf("Refit()\ngot = %v\nwant = %v", got, want)
 	}
 }


### PR DESCRIPTION
Because of the Downscale > Transform > Upscale flow, I was experiencing an issue where the background rectangle generated by Primitive was smaller than the viewBox of the final svg, leaving some unsightly whitespace. The cause was some aspect ratio rounding trouble and the simplest fix seemed to be this - adjusting the height and width of the background rectangle before minifying the thing. 

This guarantees the background rectangle and the viewbox are always the same size.